### PR TITLE
[DL-42] Investigate and Resolve Overrides

### DIFF
--- a/main/src/main/java/org/hibernate/cfg/reveng/PrimaryKeyProcessor.java
+++ b/main/src/main/java/org/hibernate/cfg/reveng/PrimaryKeyProcessor.java
@@ -21,124 +21,124 @@ public class PrimaryKeyProcessor {
 	private static final Logger log = Logger.getLogger(PrimaryKeyProcessor.class);
 
 	public static void processPrimaryKey(
-			MetaDataDialect metaDataDialect, 
-			ReverseEngineeringStrategy revengStrategy, 
-			String defaultSchema, 
-			String defaultCatalog, 
-			DatabaseCollector dbs, 
+			MetaDataDialect metaDataDialect,
+			ReverseEngineeringStrategy revengStrategy,
+			String defaultSchema,
+			String defaultCatalog,
+			DatabaseCollector dbs,
 			Table table) {
-				
+
 		List<Object[]> columns = new ArrayList<Object[]>();
 		PrimaryKey key = null;
 		Iterator<Map<String, Object>> primaryKeyIterator = null;
-		try {
-			Map<String, Object> primaryKeyRs = null;	
-			primaryKeyIterator = metaDataDialect.getPrimaryKeys(getCatalogForDBLookup(table.getCatalog(), defaultCatalog), getSchemaForDBLookup(table.getSchema(), defaultSchema), table.getName() );		
-		
-			while (primaryKeyIterator.hasNext() ) {
-				primaryKeyRs = primaryKeyIterator.next();
-				
+		List<String> t;
+		Iterator<?> cols;
+
+		List<String> userPrimaryKey = RevEngUtils.getPrimaryKeyInfoInRevengStrategy(revengStrategy, table, defaultCatalog, defaultSchema);
+		if(userPrimaryKey!=null && !userPrimaryKey.isEmpty()) {
+			key = new PrimaryKey(table);
+			key.setName(new Alias(15, "PK").toAliasString( table.getName()));
+			key.setTable(table);
+			if(table.getPrimaryKey()!=null) {
+				throw new JDBCBinderException(table + " already has a primary key!"); //TODO: ignore ?
+			}
+			table.setPrimaryKey(key);
+			t = new ArrayList<String>(userPrimaryKey);
+		} else {
+			log.warn("Rev.eng. strategy did not report any primary key columns for " + table.getName() + ". Asking the JDBC driver");
+			try {
+				Map<String, Object> primaryKeyRs = null;
+				primaryKeyIterator = metaDataDialect.getPrimaryKeys(getCatalogForDBLookup(table.getCatalog(), defaultCatalog), getSchemaForDBLookup(table.getSchema(), defaultSchema), table.getName() );
+
+				while (primaryKeyIterator.hasNext() ) {
+					primaryKeyRs = primaryKeyIterator.next();
+
 				/*String ownCatalog = primaryKeyRs.getString("TABLE_CAT");
 				 String ownSchema = primaryKeyRs.getString("TABLE_SCHEM");
 				 String ownTable = primaryKeyRs.getString("TABLE_NAME");*/
-				
-				String columnName = (String) primaryKeyRs.get("COLUMN_NAME");
-				short seq = ((Short)primaryKeyRs.get("KEY_SEQ")).shortValue();
-				String name = (String) primaryKeyRs.get("PK_NAME");
-				
-				if(key==null) {
-					key = new PrimaryKey(table);
-					key.setName(name);
-					key.setTable(table);
-					if(table.getPrimaryKey()!=null) {
-						throw new JDBCBinderException(table + " already has a primary key!"); //TODO: ignore ?
+
+					String columnName = (String) primaryKeyRs.get("COLUMN_NAME");
+					short seq = ((Short)primaryKeyRs.get("KEY_SEQ")).shortValue();
+					String name = (String) primaryKeyRs.get("PK_NAME");
+
+					if(key==null) {
+						key = new PrimaryKey(table);
+						key.setName(name);
+						key.setTable(table);
+						if(table.getPrimaryKey()!=null) {
+							throw new JDBCBinderException(table + " already has a primary key!"); //TODO: ignore ?
+						}
+						table.setPrimaryKey(key);
 					}
-					table.setPrimaryKey(key);
-				} 
-				else {
-					if(!(name==key.getName() ) && name!=null && !name.equals(key.getName() ) ) {
-						throw new JDBCBinderException("Duplicate names found for primarykey. Existing name: " + key.getName() + " JDBC name: " + name + " on table " + table);
-					}	      		
+					else {
+						if(!(name==key.getName() ) && name!=null && !name.equals(key.getName() ) ) {
+							throw new JDBCBinderException("Duplicate names found for primarykey. Existing name: " + key.getName() + " JDBC name: " + name + " on table " + table);
+						}
+					}
+
+					columns.add(new Object[] { new Short(seq), columnName});
 				}
-				
-				columns.add(new Object[] { new Short(seq), columnName});
+			} finally {
+				if (primaryKeyIterator!=null) {
+					try {
+						metaDataDialect.close(primaryKeyIterator);
+					} catch(JDBCException se) {
+						log.warn("Exception when closing resultset for reading primary key information",se);
+					}
+				}
+			}
+
+			// sort the columns accoring to the key_seq.
+			Collections.sort(columns,new Comparator<Object[]>() {
+				public int compare(Object[] o1, Object[] o2) {
+					Short left = (Short)o1[0];
+					Short right = (Short)o2[0];
+					return left.compareTo(right);
+				}
+			});
+
+			t = new ArrayList<String>(columns.size());
+			cols = columns.iterator();
+			while (cols.hasNext() ) {
+				Object[] element = (Object[]) cols.next();
+				t.add((String)element[1]);
+			}
+		}
+
+		Iterator<Map<String, Object>> suggestedPrimaryKeyStrategyName = metaDataDialect.getSuggestedPrimaryKeyStrategyName( getCatalogForDBLookup(table.getCatalog(), defaultCatalog), getSchemaForDBLookup(table.getSchema(), defaultSchema), table.getName() );
+		try {
+			if(suggestedPrimaryKeyStrategyName.hasNext()) {
+				Map<String, Object> m = suggestedPrimaryKeyStrategyName.next();
+				String suggestion = (String) m.get( "HIBERNATE_STRATEGY" );
+				if(suggestion!=null) {
+					dbs.addSuggestedIdentifierStrategy(
+							transformForModelLookup(table.getCatalog(), defaultCatalog),
+							transformForModelLookup(table.getSchema(), defaultSchema),
+							table.getName(),
+							suggestion );
+				}
 			}
 		} finally {
-			if (primaryKeyIterator!=null) {
+			if(suggestedPrimaryKeyStrategyName!=null) {
 				try {
-					metaDataDialect.close(primaryKeyIterator);
+					metaDataDialect.close(suggestedPrimaryKeyStrategyName);
 				} catch(JDBCException se) {
-					log.warn("Exception when closing resultset for reading primary key information",se);
+					log.warn("Exception while closing iterator for suggested primary key strategy name",se);
 				}
 			}
 		}
-	      
-	      // sort the columns accoring to the key_seq.
-	      Collections.sort(columns,new Comparator<Object[]>() {
-			public int compare(Object[] o1, Object[] o2) {
-				Short left = (Short)o1[0];
-				Short right = (Short)o2[0];
-				return left.compareTo(right);
-			}
-	      });
-	      
-	      List<String> t = new ArrayList<String>(columns.size());
-	      Iterator<?> cols = columns.iterator();
-	      while (cols.hasNext() ) {
-			Object[] element = (Object[]) cols.next();
-			t.add((String)element[1]);
-	      }
-	      
-	      if(key==null) {
-	      	log.warn("The JDBC driver didn't report any primary key columns in " + table.getName() + ". Asking rev.eng. strategy" );
-	      	List<String> userPrimaryKey = RevEngUtils.getPrimaryKeyInfoInRevengStrategy(revengStrategy, table, defaultCatalog, defaultSchema);	      	if(userPrimaryKey!=null && !userPrimaryKey.isEmpty()) {
-	      		key = new PrimaryKey(table);
-	      		key.setName(new Alias(15, "PK").toAliasString( table.getName()));
-	      		key.setTable(table);
-	      		if(table.getPrimaryKey()!=null) {
-	      			throw new JDBCBinderException(table + " already has a primary key!"); //TODO: ignore ?
-	      		}
-	      		table.setPrimaryKey(key);
-	      		t = new ArrayList<String>(userPrimaryKey);
-	      	} else {
-	      		log.warn("Rev.eng. strategy did not report any primary key columns for " + table.getName());
-	      	}	      	
-	      }
 
-	      Iterator<Map<String, Object>> suggestedPrimaryKeyStrategyName = metaDataDialect.getSuggestedPrimaryKeyStrategyName( getCatalogForDBLookup(table.getCatalog(), defaultCatalog), getSchemaForDBLookup(table.getSchema(), defaultSchema), table.getName() );
-	      try {
-		      if(suggestedPrimaryKeyStrategyName.hasNext()) {
-		    	  Map<String, Object> m = suggestedPrimaryKeyStrategyName.next();
-		    	  String suggestion = (String) m.get( "HIBERNATE_STRATEGY" );
-		    	  if(suggestion!=null) {
-		    		  dbs.addSuggestedIdentifierStrategy( 
-		    				  transformForModelLookup(table.getCatalog(), defaultCatalog), 
-		    				  transformForModelLookup(table.getSchema(), defaultSchema), 
-		    				  table.getName(), 
-		    				  suggestion );
-		    	  }
-		      }
-	      } finally {
-	    	  if(suggestedPrimaryKeyStrategyName!=null) {
-					try {
-						metaDataDialect.close(suggestedPrimaryKeyStrategyName);
-					} catch(JDBCException se) {
-						log.warn("Exception while closing iterator for suggested primary key strategy name",se);
-					}
-				}	    	  
-	      }
-	      	      
-	      if(key!=null) {
-	    	  cols = t.iterator();
-	    	  while (cols.hasNext() ) {
-	    		  String name = (String) cols.next();
-	    		  // should get column from table if it already exists!
-	    		  Column col = getColumn(metaDataDialect, table, name);
-	    		  key.addColumn(col);
-	    	  }
-	    	  log.debug("primary key for " + table + " -> "  + key);
-	      } 
-	     	      
+		if(key!=null) {
+			cols = t.iterator();
+			while (cols.hasNext() ) {
+				String name = (String) cols.next();
+				// should get column from table if it already exists!
+				Column col = getColumn(metaDataDialect, table, name);
+				key.addColumn(col);
+			}
+			log.debug("primary key for " + table + " -> "  + key);
+		}
+
 	}
 
 	private static String getCatalogForDBLookup(String catalog, String defaultCatalog) {

--- a/main/src/main/java/org/hibernate/tool/hbm2x/pojo/EntityPOJOClass.java
+++ b/main/src/main/java/org/hibernate/tool/hbm2x/pojo/EntityPOJOClass.java
@@ -18,6 +18,7 @@ import org.hibernate.internal.util.collections.JoinedIterator;
 import org.hibernate.mapping.Collection;
 import org.hibernate.mapping.Column;
 import org.hibernate.mapping.Component;
+import org.hibernate.mapping.ForeignKey;
 import org.hibernate.mapping.Formula;
 import org.hibernate.mapping.KeyValue;
 import org.hibernate.mapping.ManyToOne;
@@ -352,10 +353,25 @@ public class EntityPOJOClass extends BasicPOJOClass {
 		}
 
 		if(property.getValue() instanceof ToOne) {
-			String referencedEntityName = ((ToOne)property.getValue()).getReferencedEntityName();
-			PersistentClass target = md.getEntityBinding(referencedEntityName);
-			if(target!=null) {
-				referencedColumnsIterator = target.getKey().getColumnIterator();
+			ForeignKey foreignKey = property.getValue().getTable().getForeignKeys().values().stream()
+					.filter(fk -> fk.getName().equals(property.getName())).findFirst().orElse(null);
+			if (foreignKey != null) {
+				referencedColumnsIterator = foreignKey.getReferencedColumns().iterator();
+			} else {
+				List<Selectable> propertySourceColumns = new ArrayList<>();
+				property.getValue().getColumnIterator().forEachRemaining(propertySourceColumns::add);
+
+				// If no property was found in the reveng file with the same constraint name, check the DB FKs.
+				foreignKey = property.getValue().getTable().getForeignKeys().values().stream()
+						.filter(fk ->
+							fk.getReferencedEntityName().equals(((ToOne) property.getValue()).getReferencedEntityName())
+							&& fk.getColumns().equals(propertySourceColumns)
+						)
+						.findFirst()
+						.orElse(null);
+				if (foreignKey != null) {
+					referencedColumnsIterator = foreignKey.getReferencedColumns().iterator();
+				}
 			}
 		}
 

--- a/main/src/main/java/org/hibernate/tool/hbm2x/pojo/EntityPOJOClass.java
+++ b/main/src/main/java/org/hibernate/tool/hbm2x/pojo/EntityPOJOClass.java
@@ -396,7 +396,7 @@ public class EntityPOJOClass extends BasicPOJOClass {
 		while ( columns.hasNext() ) {
 			Selectable selectable = columns.next();
             Selectable referencedColumn = null;
-            if(referencedColumnsIterator!=null) {
+            if(referencedColumnsIterator!=null  && referencedColumnsIterator.hasNext()) {
             	referencedColumn = referencedColumnsIterator.next();
             }
 


### PR DESCRIPTION
1. Updated the Entity POJO Class so that for To-One relationships, the foreign key reference column names are retrieved from the property in the rev eng file, by using the constraint name.
2. Added a backup to check for database foreign keys when no property is found in the reveng file with the same constraint name, by using the property's referenced entity name and source columns.