### PR TITLE
[DL-42] Investigate and Resolve Overrides

### DIFF
--- a/main/src/main/java/org/hibernate/tool/hbm2x/pojo/EntityPOJOClass.java
+++ b/main/src/main/java/org/hibernate/tool/hbm2x/pojo/EntityPOJOClass.java
@@ -354,7 +354,7 @@ public class EntityPOJOClass extends BasicPOJOClass {
 
 		if(property.getValue() instanceof ToOne) {
 			ForeignKey foreignKey = property.getValue().getTable().getForeignKeys().values().stream()
-					.filter(fk -> fk.getName().equals(property.getName())).findFirst().orElse(null);
+					.filter(fk -> fk.getName().split("-")[0].equals(property.getName())).findFirst().orElse(null);
 			if (foreignKey != null) {
 				referencedColumnsIterator = foreignKey.getReferencedColumns().iterator();
 			} else {


### PR DESCRIPTION
1. Updated generateJoinColumnsAnnotation() so that for To-One relationships, when matching the foreign key constraint name with the property name in the reveng file, the constraint name is split by '-' to retrieve only the first part which will be the relationship's target table.
