### PR TITLE
[DL-42] Investigate and Resolve Overrides

### DIFF
--- a/main/src/main/java/org/hibernate/cfg/reveng/IndexProcessor.java
+++ b/main/src/main/java/org/hibernate/cfg/reveng/IndexProcessor.java
@@ -133,6 +133,22 @@ public class IndexProcessor {
 			// if only key matches then mark as setNaturalId(true);
 			iterator.next();
 		}
+
+		// Change the unique key name of the original primary key to contain the new 'PK-' prefix
+		// and delete the temp key
+		Iterator<UniqueKey> uniqueKeyIterator = table.getUniqueKeyIterator();
+		String originalPkName = "";
+		while(uniqueKeyIterator.hasNext()) {
+			UniqueKey uniqueKey = uniqueKeyIterator.next();
+			if (uniqueKey.getName().startsWith("PK-")) {
+				originalPkName = uniqueKey.getName().substring(3);
+				UniqueKey originalUk = uniquekeys.remove(originalPkName);
+				originalUk.setName(uniqueKey.getName());
+				uniquekeys.put(uniqueKey.getName(), originalUk);
+				uniqueKeyIterator.remove();
+				break;
+			}
+		}
 	}
 	
 	private static String getCatalogForDBLookup(String catalog, String defaultCatalog) {

--- a/main/src/main/java/org/hibernate/cfg/reveng/IndexProcessor.java
+++ b/main/src/main/java/org/hibernate/cfg/reveng/IndexProcessor.java
@@ -134,14 +134,14 @@ public class IndexProcessor {
 			iterator.next();
 		}
 
-		// Change the unique key name of the original primary key to contain the new 'PK-' prefix
+		// Change the unique key name of the original primary key to contain the new 'DWPK-' prefix
 		// and delete the temp key
 		Iterator<UniqueKey> uniqueKeyIterator = table.getUniqueKeyIterator();
 		String originalPkName = "";
 		while(uniqueKeyIterator.hasNext()) {
 			UniqueKey uniqueKey = uniqueKeyIterator.next();
-			if (uniqueKey.getName().startsWith("PK-")) {
-				originalPkName = uniqueKey.getName().substring(3);
+			if (uniqueKey.getName().startsWith("DWPK-")) {
+				originalPkName = uniqueKey.getName().substring(5);
 				UniqueKey originalUk = uniquekeys.remove(originalPkName);
 				originalUk.setName(uniqueKey.getName());
 				uniquekeys.put(uniqueKey.getName(), originalUk);

--- a/main/src/main/java/org/hibernate/cfg/reveng/PrimaryKeyProcessor.java
+++ b/main/src/main/java/org/hibernate/cfg/reveng/PrimaryKeyProcessor.java
@@ -63,7 +63,7 @@ public class PrimaryKeyProcessor {
 				UniqueKey uniqueKey = uniqueKeys.get(indexName);
 				if (uniqueKey==null) {
 					uniqueKey = new UniqueKey();
-					uniqueKey.setName("PK-" + indexName);
+					uniqueKey.setName("DWPK-" + indexName);
 					uniqueKey.setTable(table);
 					table.addUniqueKey(uniqueKey);
 					uniqueKeys.put(indexName, uniqueKey);

--- a/main/src/main/java/org/hibernate/cfg/reveng/PrimaryKeyProcessor.java
+++ b/main/src/main/java/org/hibernate/cfg/reveng/PrimaryKeyProcessor.java
@@ -56,9 +56,9 @@ public class PrimaryKeyProcessor {
 			Map<String, UniqueKey> uniqueKeys = new HashMap<String, UniqueKey>();
 
 			while (primaryKeys.hasNext() ) {
-				Map<String, Object> primaryKeyRsTest = primaryKeys.next();
-				String indexName = (String) primaryKeyRsTest.get("PK_NAME");
-				String columnName = (String) primaryKeyRsTest.get("COLUMN_NAME");
+				Map<String, Object> primaryKeyRs = primaryKeys.next();
+				String indexName = (String) primaryKeyRs.get("PK_NAME");
+				String columnName = (String) primaryKeyRs.get("COLUMN_NAME");
 
 				UniqueKey uniqueKey = uniqueKeys.get(indexName);
 				if (uniqueKey==null) {
@@ -68,7 +68,8 @@ public class PrimaryKeyProcessor {
 					table.addUniqueKey(uniqueKey);
 					uniqueKeys.put(indexName, uniqueKey);
 
-					// Add a temporary column so that this unique constraint is different from the original primary key
+					// Add a temporary column so that this unique constraint is different from the original primary key.
+					// This unique key with the temporary column will be deleted during index processing.
 					Column tempColumn = new Column("TEMP_COLUMN");
 					uniqueKey.addColumn(tempColumn);
 				}

--- a/main/src/main/java/org/hibernate/cfg/reveng/PrimaryKeyProcessor.java
+++ b/main/src/main/java/org/hibernate/cfg/reveng/PrimaryKeyProcessor.java
@@ -3,6 +3,7 @@ package org.hibernate.cfg.reveng;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -13,6 +14,7 @@ import org.hibernate.cfg.reveng.dialect.MetaDataDialect;
 import org.hibernate.mapping.Column;
 import org.hibernate.mapping.PrimaryKey;
 import org.hibernate.mapping.Table;
+import org.hibernate.mapping.UniqueKey;
 import org.hibernate.sql.Alias;
 import org.jboss.logging.Logger;
 
@@ -44,6 +46,36 @@ public class PrimaryKeyProcessor {
 			}
 			table.setPrimaryKey(key);
 			t = new ArrayList<String>(userPrimaryKey);
+
+			// Create a temporary unique key for the original primary key which is going to become a unique constraint
+			// due to the primary key override
+			Iterator<Map<String, Object>> primaryKeys = metaDataDialect.getPrimaryKeys(getCatalogForDBLookup(
+					table.getCatalog(), defaultCatalog),
+					getSchemaForDBLookup(table.getSchema(), defaultSchema),
+					table.getName());
+			Map<String, UniqueKey> uniqueKeys = new HashMap<String, UniqueKey>();
+
+			while (primaryKeys.hasNext() ) {
+				Map<String, Object> primaryKeyRsTest = primaryKeys.next();
+				String indexName = (String) primaryKeyRsTest.get("PK_NAME");
+				String columnName = (String) primaryKeyRsTest.get("COLUMN_NAME");
+
+				UniqueKey uniqueKey = uniqueKeys.get(indexName);
+				if (uniqueKey==null) {
+					uniqueKey = new UniqueKey();
+					uniqueKey.setName("PK-" + indexName);
+					uniqueKey.setTable(table);
+					table.addUniqueKey(uniqueKey);
+					uniqueKeys.put(indexName, uniqueKey);
+
+					// Add a temporary column so that this unique constraint is different from the original primary key
+					Column tempColumn = new Column("TEMP_COLUMN");
+					uniqueKey.addColumn(tempColumn);
+				}
+
+				Column column = getColumn(metaDataDialect, table, columnName);
+				uniqueKey.addColumn(column);
+			}
 		} else {
 			log.warn("Rev.eng. strategy did not report any primary key columns for " + table.getName() + ". Asking the JDBC driver");
 			try {

--- a/main/src/main/java/org/hibernate/tool/hbm2x/pojo/EntityPOJOClass.java
+++ b/main/src/main/java/org/hibernate/tool/hbm2x/pojo/EntityPOJOClass.java
@@ -354,7 +354,7 @@ public class EntityPOJOClass extends BasicPOJOClass {
 
 		if(property.getValue() instanceof ToOne) {
 			ForeignKey foreignKey = property.getValue().getTable().getForeignKeys().values().stream()
-					.filter(fk -> fk.getName().equals(property.getName())).findFirst().orElse(null);
+					.filter(fk -> fk.getName().split("-")[0].equals(property.getName())).findFirst().orElse(null);
 			if (foreignKey != null) {
 				referencedColumnsIterator = foreignKey.getReferencedColumns().iterator();
 			} else {


### PR DESCRIPTION
1. Updated the Primary Key Processor so that when setting the primary key to an override from the reveng file, a temporary table unique constraint is created with a 'PK-' prefix added to the constraint name.
2. Updated the Index Processor so that when creating the unique keys, the original primary key is renamed with the additional 'PK-' prefix and the temporary table unique key is removed.