### PR TITLE
[DL-91] Invalid relationship definitions failing with HBN v6

### DIFF
--- a/main/src/main/java/org/hibernate/cfg/reveng/ForeignKeysInfo.java
+++ b/main/src/main/java/org/hibernate/cfg/reveng/ForeignKeysInfo.java
@@ -41,8 +41,47 @@ public class ForeignKeysInfo {
 			
 			String className = revengStrategy.tableToClassName(TableIdentifier.create(referencedTable) );
 
-			ForeignKey key = fkTable.createForeignKey(fkName, columns, className, null, refColumns);			
+			// ForeignKeyKey matches only by columns and referenced columns without considering the referenced class
+			// name. Added a boolean to check if there exists a foreign key where the columns and referenced columns
+			// match, but the referenced class name is different. In this case add a temporary column to the actual
+			// foreign key so that hibernate sees this as a different key, then remove it once hibernate returns
+			// the newly created key.
+			boolean differentTargetFound = fkTable.getForeignKeys().keySet().stream().anyMatch(fk -> {
+				String keyDef = fk.toString();
+				String colsDef = keyDef.substring(keyDef.indexOf("ForeignKeyKey{columns=[")+23,
+						keyDef.indexOf("], referencedClassName='"));
+				String[] colsStr = colsDef.split("\\s*,\\s*");
+				List<Column> cols = new ArrayList<>();
+				for (String col: colsStr) {
+					String colName = col.substring(col.indexOf("org.hibernate.mapping.Column(")+29, col.length()-1);
+					cols.add(new Column(colName));
+				}
+				String classDef = keyDef.substring(keyDef.indexOf(", referencedClassName='")+23,
+						keyDef.indexOf("', referencedColumns="));
+				String refColsDef = keyDef.substring(keyDef.indexOf("', referencedColumns=[")+22,
+						keyDef.length()-2);
+				String[] refColsStr = refColsDef.split("\\s*,\\s*");
+				List<Column> refCols = new ArrayList<>();
+				for (String refCol: refColsStr) {
+					String refColName = refCol.substring(refCol.indexOf("org.hibernate.mapping.Column(")+29,
+							refCol.length()-1);
+					refCols.add(new Column(refColName));
+				}
+
+				return columns.equals(cols) && refColumns.equals(refCols) && !className.equals(classDef);
+			});
+
+			Column tempColumn = new Column("TEMP_COLUMN");
+			if (differentTargetFound) {
+				refColumns.add(tempColumn);
+			}
+
+			ForeignKey key = fkTable.createForeignKey(fkName, columns, className, null, refColumns);
 			key.setReferencedTable(referencedTable);
+
+			if (differentTargetFound) {
+				key.getReferencedColumns().remove(tempColumn);
+			}
 
 			addToMultiMap(oneToManyCandidates, className, key);				
 		}

--- a/main/src/main/java/org/hibernate/cfg/reveng/ForeignKeysInfo.java
+++ b/main/src/main/java/org/hibernate/cfg/reveng/ForeignKeysInfo.java
@@ -50,23 +50,12 @@ public class ForeignKeysInfo {
 				String keyDef = fk.toString();
 				String colsDef = keyDef.substring(keyDef.indexOf("ForeignKeyKey{columns=[")+23,
 						keyDef.indexOf("], referencedClassName='"));
-				String[] colsStr = colsDef.split("\\s*,\\s*");
-				List<Column> cols = new ArrayList<>();
-				for (String col: colsStr) {
-					String colName = col.substring(col.indexOf("org.hibernate.mapping.Column(")+29, col.length()-1);
-					cols.add(new Column(colName));
-				}
+				List<Column> cols = createColumnList(colsDef);
 				String classDef = keyDef.substring(keyDef.indexOf(", referencedClassName='")+23,
 						keyDef.indexOf("', referencedColumns="));
 				String refColsDef = keyDef.substring(keyDef.indexOf("', referencedColumns=[")+22,
 						keyDef.length()-2);
-				String[] refColsStr = refColsDef.split("\\s*,\\s*");
-				List<Column> refCols = new ArrayList<>();
-				for (String refCol: refColsStr) {
-					String refColName = refCol.substring(refCol.indexOf("org.hibernate.mapping.Column(")+29,
-							refCol.length()-1);
-					refCols.add(new Column(refColName));
-				}
+				List<Column> refCols = createColumnList(refColsDef);
 
 				return columns.equals(cols) && refColumns.equals(refCols) && !className.equals(classDef);
 			});
@@ -86,6 +75,16 @@ public class ForeignKeysInfo {
 			addToMultiMap(oneToManyCandidates, className, key);				
 		}
 		return oneToManyCandidates;
+	}
+
+	private List<Column> createColumnList(String columnDef) {
+		String[] colsStr = columnDef.split("\\s*,\\s*");
+		List<Column> cols = new ArrayList<>();
+		for (String col: colsStr) {
+			String colName = col.substring(col.indexOf("org.hibernate.mapping.Column(")+29, col.length()-1);
+			cols.add(new Column(colName));
+		}
+		return cols;
 	}
 
 	private void addToMultiMap(Map<String, List<ForeignKey>> multimap, String key, ForeignKey item) {

--- a/main/src/main/java/org/hibernate/tool/hbm2x/pojo/EntityPOJOClass.java
+++ b/main/src/main/java/org/hibernate/tool/hbm2x/pojo/EntityPOJOClass.java
@@ -708,7 +708,8 @@ public class EntityPOJOClass extends BasicPOJOClass {
 		while ( ! isOtherSide && properties.hasNext() ) {
 			Property manyProperty = (Property) properties.next();
 			Value manyValue = manyProperty.getValue();
-			if ( manyValue != null && manyValue instanceof ManyToOne ) {
+			if ( manyValue != null && manyValue instanceof ManyToOne
+				&& ((ManyToOne) manyValue).getReferencedEntityName().equals(collection.getOwner().getEntityName())) {
 				if ( joinColumns.size() == manyValue.getColumnSpan() ) {
 					isOtherSide = true;
 					Iterator<?> it = manyValue.getColumnIterator();


### PR DESCRIPTION
1. Updated getOneToManyMappedBy() so that whenever populating the relationship's mappedBy attribute, while retrieving the inverse many to one properties, the entity name is also used alongside the join columns to find the correct property name.
2. Updated the Foreign Key process function, since whenever creating a foreign key by calling hibernate's createForeignKey() function, the method checks for existing foreign keys by matching only with the source columns and the referenced columns. This causes an issue whenever there are two separate foreign keys using the same source columns and referenced columns but a different referenced class name. To bypass this incorrect check, an update was carried out so that in such cases, a temporary column is added to the key and hibernate does not find a match. This returns a new key and the temporary column is then deleted.
