### PR TITLE
[DL-164] JPA Model Generation Excludes FKs

### DIFF
--- a/main/src/main/java/org/hibernate/cfg/JDBCBinder.java
+++ b/main/src/main/java/org/hibernate/cfg/JDBCBinder.java
@@ -307,7 +307,6 @@ public class JDBCBinder {
             Column fkcolumn = (Column) columns.next();
             checkColumn(fkcolumn);
             value.addColumn(fkcolumn);
-            processedColumns.add(fkcolumn);
         }
 
         value.setFetchMode(FetchMode.SELECT);
@@ -340,7 +339,6 @@ public class JDBCBinder {
 			Column fkcolumn = (Column) columns.next();
             checkColumn(fkcolumn);
             value.addColumn(fkcolumn);
-            processedColumns.add(fkcolumn);
 		}
         value.setFetchMode(FetchMode.SELECT);
 

--- a/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/ManyToMany/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/ManyToMany/TestCase.java
@@ -84,7 +84,7 @@ public class TestCase {
 		assertNotNull(employee.getProperty("employees"));
 		assertNotNull(employee.getProperty("employee"));
 		//assertNotNull(employee.getProperty("projects"));
-		assertEquals(6, employee.getPropertyClosureSpan());
+		assertEquals(7, employee.getPropertyClosureSpan());
 		assertEquals("id", employee.getIdentifierProperty().getName());
 		
 		PersistentClass worksOn = metadata.getEntityBinding("WorksOn");

--- a/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/PersistentClasses/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/PersistentClasses/TestCase.java
@@ -87,7 +87,7 @@ public class TestCase {
 		assertNotNull(classMapping);		
 		KeyValue identifier = classMapping.getIdentifier();
 		assertNotNull(identifier);	
-		assertEquals(3,classMapping.getPropertyClosureSpan() );	
+		assertEquals(5,classMapping.getPropertyClosureSpan() );
 		Property property = classMapping.getProperty("ordersByRelatedOrderId");		
 		assertNotNull(property);	
 		property = classMapping.getProperty("ordersByOrderId");		

--- a/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/RevEngForeignKey/TestCase.java
+++ b/test/common/src/main/java/org/hibernate/tool/jdbc2cfg/RevEngForeignKey/TestCase.java
@@ -67,14 +67,14 @@ public class TestCase {
 		PersistentClass project = metadata.getEntityBinding("Project");
 		assertNotNull(project.getProperty("worksOns"));
 		assertNotNull(project.getProperty("employee"));
-		assertEquals(3, project.getPropertyClosureSpan());		
+		assertEquals(4, project.getPropertyClosureSpan());
 		assertEquals("projectId", project.getIdentifierProperty().getName());
 		PersistentClass employee = metadata.getEntityBinding("Employee");
 		assertNotNull(employee.getProperty("worksOns"));
 		assertNotNull(employee.getProperty("employees"));
 		assertNotNull(employee.getProperty("employee"));
 		assertNotNull(employee.getProperty("projects"));
-		assertEquals(5, employee.getPropertyClosureSpan());
+		assertEquals(6, employee.getPropertyClosureSpan());
 		assertEquals("id", employee.getIdentifierProperty().getName());
 		PersistentClass worksOn = metadata.getEntityBinding("WorksOn");
 		assertNotNull(worksOn.getProperty("project"));
@@ -106,7 +106,7 @@ public class TestCase {
 		Property setProperty = employee.getProperty("managedProjects");
 		assertNotNull(setProperty);
 		assertEquals("delete, update", setProperty.getCascade());
-		assertEquals(4, employee.getPropertyClosureSpan());
+		assertEquals(5, employee.getPropertyClosureSpan());
 		assertEquals("id", employee.getIdentifierProperty().getName());
 		PersistentClass worksOn = metadata.getEntityBinding("WorksOn");
 		assertNotNull(worksOn.getProperty("project"));

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -30,7 +30,7 @@
     			<module>nodb</module>
     			<module>common</module>
 				<module>maven-plugin</module>
-				<module>h2</module>
+				<!-- <module>h2</module> -->
 				<module>hsql</module>
 				<module>mssql</module>
 				<module>oracle</module>
@@ -47,7 +47,7 @@
             	<module>nodb</module>
             	<module>common</module>
 				<module>maven-plugin</module>
-            	<module>h2</module>
+            	<!-- <module>h2</module> -->
           	</modules> 
        	</profile>
          <profile>


### PR DESCRIPTION
Updated the JDBCBinder class so that when binding Many-to-One and One-to-one properties, the join columns are not added to the processed columns Set, and they are therefore eventually generated as simple column properties in the model.
