### PR TITLE
[DL-570] Add columnDefinition information in JPA models

### DIFF
--- a/main/src/main/java/org/hibernate/cfg/reveng/BasicColumnProcessor.java
+++ b/main/src/main/java/org/hibernate/cfg/reveng/BasicColumnProcessor.java
@@ -37,7 +37,7 @@ public class BasicColumnProcessor {
 				columnRs = (Map<?, ?>) columnIterator.next();
 				String tableName = (String) columnRs.get("TABLE_NAME");
 				int sqlType = ((Integer)columnRs.get("DATA_TYPE")).intValue();
-				//String sqlTypeName = (String) columnRs.get("TYPE_NAME");
+				String sqlTypeName = (String) columnRs.get("TYPE_NAME");
 				String columnName = (String) columnRs.get("COLUMN_NAME");
 				String comment = (String) columnRs.get("REMARKS");
 				
@@ -78,7 +78,7 @@ public class BasicColumnProcessor {
 				}
 								
 				//TODO: column.setSqlType(sqlTypeName); //this does not work 'cos the precision/scale/length are not retured in TYPE_NAME
-				//column.setSqlType(sqlTypeName);
+				column.setSqlType(sqlTypeName);
 				column.setComment(comment);
 				column.setSqlTypeCode(new Integer(sqlType) );
                 if(intBounds(size) ) {

--- a/main/src/main/java/org/hibernate/tool/hbm2x/pojo/BasicPOJOClass.java
+++ b/main/src/main/java/org/hibernate/tool/hbm2x/pojo/BasicPOJOClass.java
@@ -466,11 +466,13 @@ abstract public class BasicPOJOClass implements POJOClass, MetaAttributeConstant
 		if(!updatable) {
 				annotations.append( ", updatable=" ).append( updatable );
 		}
-		
+
+		/*
 		String sqlType = column.getSqlType();
 		if ( StringHelper.isNotEmpty( sqlType ) ) {
 			annotations.append( ", columnDefinition=\"" ).append( sqlType ).append( "\"" );
 		}
+		*/
 				
 	}
 


### PR DESCRIPTION
The Column.sqlTypeName attribute is now populated with the actual DB type name in order to use it in the hibernate templates and generate the respective attribute converters in the models.

The columnDefinition attribute generation was removed since we do not require this information any longer. If needed in the future, this can be re-introduced.